### PR TITLE
Ability to scroll to before or after a given date

### DIFF
--- a/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -48,6 +48,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
         }
         
         checkScrollToPreviousDisabled()
+        checkScrollToNextDisabled()
         
         calendarView.presentedDate = CVDate(date: presentedMonthView.date, calendar: calendar)
     }
@@ -70,6 +71,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
         monthViews[identifier] = monthView
         scrollView.addSubview(monthView)
         checkScrollToPreviousDisabled()
+        checkScrollToNextDisabled()
         calendarView.coordinator?.disableDays(in: presentedMonthView)
     }
     
@@ -338,11 +340,24 @@ extension CVCalendarMonthContentViewController {
     func checkScrollToPreviousDisabled() {
         let calendar = self.calendarView.delegate?.calendar?() ?? Calendar.current
         if let presentedMonth = monthViews[presented],
+            let disableScrollingBeforeDate = calendarView.disableScrollingBeforeDate {
+            let convertedDate = CVDate(date: disableScrollingBeforeDate, calendar: calendar)
+            presentedMonth.mapDayViews({ dayView in
+                if matchedDays(convertedDate, dayView.date) {
+                    presentedMonth.allowScrollToPreviousMonth = false
+                }
+            })
+        }
+    }
+    
+    func checkScrollToNextDisabled() {
+        let calendar = self.calendarView.delegate?.calendar?() ?? Calendar.current
+        if let presentedMonth = monthViews[presented],
             let disableScrollingBeyondDate = calendarView.disableScrollingBeyondDate {
             let convertedDate = CVDate(date: disableScrollingBeyondDate, calendar: calendar)
             presentedMonth.mapDayViews({ dayView in
                 if matchedDays(convertedDate, dayView.date) {
-                    presentedMonth.allowScrollToPreviousMonth = false
+                    presentedMonth.allowScrollToNextMonth = false
                 }
             })
         }
@@ -433,6 +448,12 @@ extension CVCalendarMonthContentViewController {
         //restricts scrolling to previous months
         if monthViews[presented]?.allowScrollToPreviousMonth == false,
             scrollView.contentOffset.x < scrollView.frame.width {
+            scrollView.setContentOffset(CGPoint(x: scrollView.frame.width, y: 0), animated: false)
+            return
+        }
+        
+        if monthViews[presented]?.allowScrollToNextMonth == false,
+            scrollView.contentOffset.x > scrollView.frame.width {
             scrollView.setContentOffset(CGPoint(x: scrollView.frame.width, y: 0), animated: false)
             return
         }

--- a/CVCalendar/CVCalendarMonthView.swift
+++ b/CVCalendar/CVCalendarMonthView.swift
@@ -27,7 +27,7 @@ public final class CVCalendarMonthView: UIView {
     }
 
     var allowScrollToPreviousMonth = true
-    var allowScrollToNextMoneth = true
+    var allowScrollToNextMonth = true
     
     // MARK: - Public properties
 

--- a/CVCalendar/CVCalendarMonthView.swift
+++ b/CVCalendar/CVCalendarMonthView.swift
@@ -27,6 +27,7 @@ public final class CVCalendarMonthView: UIView {
     }
 
     var allowScrollToPreviousMonth = true
+    var allowScrollToNextMoneth = true
     
     // MARK: - Public properties
 

--- a/CVCalendar/CVCalendarView.swift
+++ b/CVCalendar/CVCalendarView.swift
@@ -109,9 +109,18 @@ public final class CVCalendarView: UIView {
         }
     }
     
-    public var disableScrollingBeyondDate: Date? {
+    public var disableScrollingBeforeDate: Date? {
         get {
             if let delegate = delegate, let date = delegate.disableScrollingBeforeDate?() {
+                return date
+            }
+            return nil
+        }
+    }
+    
+    public var disableScrollingBeyondDate: Date? {
+        get {
+            if let delegate = delegate, let date = delegate.disableScrollingBeyondDate?() {
                 return date
             }
             return nil

--- a/CVCalendar/CVCalendarViewDelegate.swift
+++ b/CVCalendar/CVCalendarViewDelegate.swift
@@ -53,6 +53,7 @@ public protocol CVCalendarViewDelegate {
     @objc optional func shouldSelectRange() -> Bool
     @objc optional func didSelectRange(from startDayView: DayView, to endDayView: DayView)
     @objc optional func disableScrollingBeforeDate() -> Date
+    @objc optional func disableScrollingBeyondDate() -> Date
     @objc optional func maxSelectableRange() -> Int
     @objc optional func earliestSelectableDate() -> Date
     @objc optional func latestSelectableDate() -> Date


### PR DESCRIPTION
I noticed that by providing a date for "disableScrollingBeyondDate" variable in CVCalendarView.swift, it will in fact disable scrolling to any calendar month view BEFORE the provided date. This functionality is completely backwards from what the name implies it does (i.e. I would expect it to disallow scrolling to dates BEYOND the provided date). Therefore, I modified the functionality so that it actually does what it says it does, and added a new function called "disableScrollingBeforeDate" to do what "disableScrollingBeyondDate" currently does: namely, disallow scrolling to dates before the provided date.