### PR TITLE
Call interactionSetup() when refreshing

### DIFF
--- a/CVCalendar/CVCalendarContentViewController.swift
+++ b/CVCalendar/CVCalendarContentViewController.swift
@@ -85,6 +85,7 @@ extension CVCalendarContentViewController {
                 dayView.preliminarySetup()
                 dayView.supplementarySetup()
                 dayView.topMarkerSetup()
+                dayView.interactionSetup()
             }
         }
     }

--- a/CVCalendar/CVCalendarContentViewController.swift
+++ b/CVCalendar/CVCalendarContentViewController.swift
@@ -86,6 +86,7 @@ extension CVCalendarContentViewController {
                 dayView.supplementarySetup()
                 dayView.topMarkerSetup()
                 dayView.interactionSetup()
+                dayView.labelSetup()
             }
         }
     }


### PR DESCRIPTION
Currently, calling 'refreshPresentedMonth' does not update the "isUserInteractionEnabled" (can / can not be selected) and the labelColour (indicator if the DayView is user interact able)