### PR TITLE
Added static library target.

### DIFF
--- a/CVCalendar.xcodeproj/project.pbxproj
+++ b/CVCalendar.xcodeproj/project.pbxproj
@@ -38,7 +38,49 @@
 		45D9D9021C50073F006673B2 /* CVWeekdaySymbolType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8E71C50073F006673B2 /* CVWeekdaySymbolType.swift */; };
 		56D2797F1D49DC18009987A6 /* CVStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D2797E1D49DC18009987A6 /* CVStatus.swift */; };
 		56D279811D4A20A4009987A6 /* CVPresent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D279801D4A20A4009987A6 /* CVPresent.swift */; };
+		7C84562D20D294E6008887C6 /* CVCalendarContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8CE1C50073F006673B2 /* CVCalendarContentViewController.swift */; };
+		7C84562E20D294E6008887C6 /* CVCalendarMonthContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8D41C50073F006673B2 /* CVCalendarMonthContentViewController.swift */; };
+		7C84562F20D294E6008887C6 /* CVCalendarWeekContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8DE1C50073F006673B2 /* CVCalendarWeekContentViewController.swift */; };
+		7C84563020D294E6008887C6 /* CVCalendarMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8D21C50073F006673B2 /* CVCalendarMenuView.swift */; };
+		7C84563120D294E6008887C6 /* CVCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8D71C50073F006673B2 /* CVCalendarView.swift */; };
+		7C84563220D294E6008887C6 /* CVAuxiliaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8CD1C50073F006673B2 /* CVAuxiliaryView.swift */; };
+		7C84563320D294E6008887C6 /* CVCalendarDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8CF1C50073F006673B2 /* CVCalendarDayView.swift */; };
+		7C84563420D294E6008887C6 /* CVCalendarMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8D51C50073F006673B2 /* CVCalendarMonthView.swift */; };
+		7C84563520D294E6008887C6 /* CVCalendarWeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8E01C50073F006673B2 /* CVCalendarWeekView.swift */; };
+		7C84563620D294E6008887C6 /* CVCalendarContentPresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1846DE771E77382D00339E93 /* CVCalendarContentPresentationCoordinator.swift */; };
+		7C84563720D294E6008887C6 /* CVCalendarDayViewControlCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8D01C50073F006673B2 /* CVCalendarDayViewControlCoordinator.swift */; };
+		7C84563820D294E6008887C6 /* CVCalendarTouchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8D61C50073F006673B2 /* CVCalendarTouchController.swift */; };
+		7C84563920D294E6008887C6 /* CVCalendarViewAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8D81C50073F006673B2 /* CVCalendarViewAnimator.swift */; };
+		7C84563A20D294E6008887C6 /* CVCalendarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8D11C50073F006673B2 /* CVCalendarManager.swift */; };
+		7C84563B20D294E6008887C6 /* CVCalendarViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8DA1C50073F006673B2 /* CVCalendarViewAppearance.swift */; };
+		7C84563C20D294E6008887C6 /* CVDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8E11C50073F006673B2 /* CVDate.swift */; };
+		7C84563D20D294E6008887C6 /* CVSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8E51C50073F006673B2 /* CVSet.swift */; };
+		7C84563E20D294E6008887C6 /* CVCalendarMenuViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8D31C50073F006673B2 /* CVCalendarMenuViewDelegate.swift */; };
+		7C84563F20D294E6008887C6 /* CVCalendarViewAnimatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8D91C50073F006673B2 /* CVCalendarViewAnimatorDelegate.swift */; };
+		7C84564020D294E6008887C6 /* CVCalendarViewAppearanceDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8DB1C50073F006673B2 /* CVCalendarViewAppearanceDelegate.swift */; };
+		7C84564120D294E6008887C6 /* CVCalendarViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8DC1C50073F006673B2 /* CVCalendarViewDelegate.swift */; };
+		7C84564220D294E6008887C6 /* CVCalendarViewPresentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8DD1C50073F006673B2 /* CVCalendarViewPresentationMode.swift */; };
+		7C84564320D294E6008887C6 /* CVCalendarWeekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8DF1C50073F006673B2 /* CVCalendarWeekday.swift */; };
+		7C84564420D294E6008887C6 /* CVRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8E21C50073F006673B2 /* CVRange.swift */; };
+		7C84564520D294E6008887C6 /* CVScrollDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8E31C50073F006673B2 /* CVScrollDirection.swift */; };
+		7C84564620D294E6008887C6 /* CVSelectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8E41C50073F006673B2 /* CVSelectionType.swift */; };
+		7C84564720D294E6008887C6 /* CVShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8E61C50073F006673B2 /* CVShape.swift */; };
+		7C84564820D294E6008887C6 /* CVWeekdaySymbolType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D9D8E71C50073F006673B2 /* CVWeekdaySymbolType.swift */; };
+		7C84564920D294E6008887C6 /* CVStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D2797E1D49DC18009987A6 /* CVStatus.swift */; };
+		7C84564A20D294E6008887C6 /* CVPresent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D279801D4A20A4009987A6 /* CVPresent.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		7C84562420D2944F008887C6 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		1846DE771E77382D00339E93 /* CVCalendarContentPresentationCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVCalendarContentPresentationCoordinator.swift; sourceTree = "<group>"; };
@@ -74,10 +116,18 @@
 		45D9D8E71C50073F006673B2 /* CVWeekdaySymbolType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVWeekdaySymbolType.swift; sourceTree = "<group>"; };
 		56D2797E1D49DC18009987A6 /* CVStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVStatus.swift; sourceTree = "<group>"; };
 		56D279801D4A20A4009987A6 /* CVPresent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVPresent.swift; sourceTree = "<group>"; };
+		7C84562620D2944F008887C6 /* libCVCalendar.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCVCalendar.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		45D9D8AF1C5006AA006673B2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7C84562320D2944F008887C6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -99,6 +149,7 @@
 			isa = PBXGroup;
 			children = (
 				45D9D8B31C5006AA006673B2 /* CVCalendar.framework */,
+				7C84562620D2944F008887C6 /* libCVCalendar.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -230,19 +281,41 @@
 			productReference = 45D9D8B31C5006AA006673B2 /* CVCalendar.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		7C84562520D2944F008887C6 /* libCVCalendar */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7C84562C20D2944F008887C6 /* Build configuration list for PBXNativeTarget "libCVCalendar" */;
+			buildPhases = (
+				7C84562220D2944F008887C6 /* Sources */,
+				7C84562320D2944F008887C6 /* Frameworks */,
+				7C84562420D2944F008887C6 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = libCVCalendar;
+			productName = libCVCalendar;
+			productReference = 7C84562620D2944F008887C6 /* libCVCalendar.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		45D9D8AA1C5006AA006673B2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0720;
+				LastSwiftUpdateCheck = 0940;
 				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = GameApp;
 				TargetAttributes = {
 					45D9D8B21C5006AA006673B2 = {
 						CreatedOnToolsVersion = 7.2;
 						LastSwiftMigration = 0900;
+					};
+					7C84562520D2944F008887C6 = {
+						CreatedOnToolsVersion = 9.4;
+						DevelopmentTeam = YB42T69E5P;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -259,6 +332,7 @@
 			projectRoot = "";
 			targets = (
 				45D9D8B21C5006AA006673B2 /* CVCalendar */,
+				7C84562520D2944F008887C6 /* libCVCalendar */,
 			);
 		};
 /* End PBXProject section */
@@ -308,6 +382,43 @@
 				45D9D8FC1C50073F006673B2 /* CVDate.swift in Sources */,
 				45D9D8ED1C50073F006673B2 /* CVCalendarMenuView.swift in Sources */,
 				45D9D8E91C50073F006673B2 /* CVCalendarContentViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7C84562220D2944F008887C6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7C84563420D294E6008887C6 /* CVCalendarMonthView.swift in Sources */,
+				7C84562E20D294E6008887C6 /* CVCalendarMonthContentViewController.swift in Sources */,
+				7C84563F20D294E6008887C6 /* CVCalendarViewAnimatorDelegate.swift in Sources */,
+				7C84563720D294E6008887C6 /* CVCalendarDayViewControlCoordinator.swift in Sources */,
+				7C84562D20D294E6008887C6 /* CVCalendarContentViewController.swift in Sources */,
+				7C84563E20D294E6008887C6 /* CVCalendarMenuViewDelegate.swift in Sources */,
+				7C84564420D294E6008887C6 /* CVRange.swift in Sources */,
+				7C84563B20D294E6008887C6 /* CVCalendarViewAppearance.swift in Sources */,
+				7C84564320D294E6008887C6 /* CVCalendarWeekday.swift in Sources */,
+				7C84564620D294E6008887C6 /* CVSelectionType.swift in Sources */,
+				7C84563920D294E6008887C6 /* CVCalendarViewAnimator.swift in Sources */,
+				7C84563820D294E6008887C6 /* CVCalendarTouchController.swift in Sources */,
+				7C84564A20D294E6008887C6 /* CVPresent.swift in Sources */,
+				7C84563620D294E6008887C6 /* CVCalendarContentPresentationCoordinator.swift in Sources */,
+				7C84564120D294E6008887C6 /* CVCalendarViewDelegate.swift in Sources */,
+				7C84564020D294E6008887C6 /* CVCalendarViewAppearanceDelegate.swift in Sources */,
+				7C84563020D294E6008887C6 /* CVCalendarMenuView.swift in Sources */,
+				7C84563A20D294E6008887C6 /* CVCalendarManager.swift in Sources */,
+				7C84564220D294E6008887C6 /* CVCalendarViewPresentationMode.swift in Sources */,
+				7C84563520D294E6008887C6 /* CVCalendarWeekView.swift in Sources */,
+				7C84563320D294E6008887C6 /* CVCalendarDayView.swift in Sources */,
+				7C84563120D294E6008887C6 /* CVCalendarView.swift in Sources */,
+				7C84563220D294E6008887C6 /* CVAuxiliaryView.swift in Sources */,
+				7C84564920D294E6008887C6 /* CVStatus.swift in Sources */,
+				7C84564520D294E6008887C6 /* CVScrollDirection.swift in Sources */,
+				7C84564720D294E6008887C6 /* CVShape.swift in Sources */,
+				7C84563C20D294E6008887C6 /* CVDate.swift in Sources */,
+				7C84563D20D294E6008887C6 /* CVSet.swift in Sources */,
+				7C84562F20D294E6008887C6 /* CVCalendarWeekContentViewController.swift in Sources */,
+				7C84564820D294E6008887C6 /* CVWeekdaySymbolType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -463,6 +574,38 @@
 			};
 			name = Release;
 		};
+		7C84562A20D2944F008887C6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = YB42T69E5P;
+				EXECUTABLE_PREFIX = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				PRODUCT_MODULE_NAME = CVCalendar;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		7C84562B20D2944F008887C6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = YB42T69E5P;
+				EXECUTABLE_PREFIX = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				PRODUCT_MODULE_NAME = CVCalendar;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -480,6 +623,15 @@
 			buildConfigurations = (
 				45D9D8C81C5006AA006673B2 /* Debug */,
 				45D9D8C91C5006AA006673B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7C84562C20D2944F008887C6 /* Build configuration list for PBXNativeTarget "libCVCalendar" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7C84562A20D2944F008887C6 /* Debug */,
+				7C84562B20D2944F008887C6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
CVCalendar is a great candidate as a static library target largely because there are no resources to manage. Framework targets tend to be easier to work with. They provide an import header and a module map file that simplifies the process of linking into the code, regardless if the main app is Objective-C or Swift-based.

However, there is one downside to using frameworks -- they impact initial app loading times (see https://developer.apple.com/videos/play/wwdc2016/406/). This PR intends on providing a means for those developers who are looking to squeeze out as much of an improvement to app startup as possible via a static library target.

Because Swift is not yet ABI stable, this project is designed to be used as a child project of projects that link against the static library target. To use the static library independently of this project being a child project, additional work can be done to generate a module map file and corresponding Swift and C import headers. However, that is beyond the scope of this MR and should be done by those familiar with the process in their own setups.

Maintenance of this target is pretty straightforward. In almost all cases, the only thing that needs to be done is to ensure new files that are added to the framework target are also added to the static library target. That's it!