### PR TITLE
Swift4.2

### DIFF
--- a/CVCalendar Demo/CVCalendar Demo.xcodeproj/project.pbxproj
+++ b/CVCalendar Demo/CVCalendar Demo.xcodeproj/project.pbxproj
@@ -491,7 +491,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.gameapp.production.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -504,7 +504,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.gameapp.production.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/CVCalendar Demo/CVCalendar Demo.xcodeproj/project.pbxproj
+++ b/CVCalendar Demo/CVCalendar Demo.xcodeproj/project.pbxproj
@@ -43,7 +43,6 @@
 		564E035E1D51DA100088B8D3 /* CVShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E03401D51DA100088B8D3 /* CVShape.swift */; };
 		564E035F1D51DA100088B8D3 /* CVStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E03411D51DA100088B8D3 /* CVStatus.swift */; };
 		564E03601D51DA100088B8D3 /* CVWeekdaySymbolType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E03421D51DA100088B8D3 /* CVWeekdaySymbolType.swift */; };
-		564E03611D51DA100088B8D3 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 564E03431D51DA100088B8D3 /* Info.plist */; };
 		AAAC86141E4E57C100D098DF /* CVCalendarContentPresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAC86131E4E57C100D098DF /* CVCalendarContentPresentationCoordinator.swift */; };
 /* End PBXBuildFile section */
 
@@ -265,7 +264,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = GameApp;
 				TargetAttributes = {
 					55E122171A588CB60013B002 = {
@@ -274,7 +273,7 @@
 					};
 					55E1222C1A588CB60013B002 = {
 						CreatedOnToolsVersion = 6.1.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1000;
 						TestTargetID = 55E122171A588CB60013B002;
 					};
 				};
@@ -303,7 +302,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				564E03611D51DA100088B8D3 /* Info.plist in Resources */,
 				55E122231A588CB60013B002 /* Main.storyboard in Resources */,
 				55E122281A588CB60013B002 /* LaunchScreen.xib in Resources */,
 				55E122251A588CB60013B002 /* Images.xcassets in Resources */,
@@ -406,14 +404,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -452,14 +458,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -525,7 +539,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.gameapp.production.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CVCalendar Demo.app/CVCalendar Demo";
 			};
 			name = Debug;
@@ -542,7 +557,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.gameapp.production.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CVCalendar Demo.app/CVCalendar Demo";
 			};
 			name = Release;

--- a/CVCalendar Demo/CVCalendar Demo/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/CVCalendar Demo/CVCalendar Demo/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -39,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/CVCalendar Demo/CVCalendar Demo/ViewController.swift
+++ b/CVCalendar Demo/CVCalendar Demo/ViewController.swift
@@ -130,7 +130,7 @@ extension ViewController: CVCalendarViewDelegate, CVCalendarMenuViewDelegate {
             updatedMonthLabel.transform = CGAffineTransform(translationX: 0, y: offset)
             updatedMonthLabel.transform = CGAffineTransform(scaleX: 1, y: 0.1)
             
-            UIView.animate(withDuration: 0.35, delay: 0, options: UIViewAnimationOptions.curveEaseIn, animations: {
+            UIView.animate(withDuration: 0.35, delay: 0, options: UIView.AnimationOptions.curveEaseIn, animations: {
                 self.animationFinished = false
                 self.monthLabel.transform = CGAffineTransform(translationX: 0, y: -offset)
                 self.monthLabel.transform = CGAffineTransform(scaleX: 1, y: 0.1)

--- a/CVCalendar.xcodeproj/project.pbxproj
+++ b/CVCalendar.xcodeproj/project.pbxproj
@@ -242,7 +242,7 @@
 				TargetAttributes = {
 					45D9D8B21C5006AA006673B2 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1000;
 					};
 				};
 			};
@@ -438,7 +438,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -459,7 +459,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/CVCalendar/CVCalendarContentPresentationCoordinator.swift
+++ b/CVCalendar/CVCalendarContentPresentationCoordinator.swift
@@ -23,7 +23,7 @@ extension CVCalendarContentPresentationCoordinator {
           }
 
           UIView.animate(withDuration: 0.5, delay: 0,
-                         options: UIViewAnimationOptions(),
+                         options: UIView.AnimationOptions(),
                          animations: {
             dayView.alpha = visible ? 1 : 0
           }, completion: { _ in

--- a/CVCalendar/CVCalendarContentViewController.swift
+++ b/CVCalendar/CVCalendarContentViewController.swift
@@ -226,12 +226,12 @@ extension CVCalendarContentViewController {
 
 
             for constraintIn in calendarView.constraints where
-                constraintIn.firstAttribute == NSLayoutAttribute.height {
+                constraintIn.firstAttribute == NSLayoutConstraint.Attribute.height {
                     constraintIn.constant = height
 
                     if animated {
                         UIView.animate(withDuration: 0.2, delay: 0,
-                                                   options: UIViewAnimationOptions.curveLinear,
+                                                   options: UIView.AnimationOptions.curveLinear,
                                                    animations: { [weak self] in
                             self?.layoutViews(viewsToLayout, toHeight: height)
                         }) { [weak self] _ in

--- a/CVCalendar/CVCalendarContentViewController.swift
+++ b/CVCalendar/CVCalendarContentViewController.swift
@@ -11,13 +11,13 @@ import UIKit
 public typealias Identifier = String
 open class CVCalendarContentViewController: UIViewController {
     // MARK: - Constants
-    open let previous = "Previous"
-    open let presented = "Presented"
-    open let following = "Following"
+    public let previous = "Previous"
+    public let presented = "Presented"
+    public let following = "Following"
 
     // MARK: - Public Properties
-    open unowned let calendarView: CalendarView
-    open let scrollView: UIScrollView
+    public unowned let calendarView: CalendarView
+    public let scrollView: UIScrollView
 
     open var presentedMonthView: MonthView
 

--- a/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar/CVCalendarDayView.swift
@@ -394,7 +394,7 @@ extension CVCalendarDayView {
                             withDuration: 0.3, delay: 0,
                             usingSpringWithDamping: 0.6,
                             initialSpringVelocity: 0,
-                            options: UIViewAnimationOptions.curveEaseOut,
+                            options: UIView.AnimationOptions.curveEaseOut,
                             animations: {
                                 dotMarker.transform = transform
                         },
@@ -451,7 +451,7 @@ extension CVCalendarDayView {
         if straight && angle < endAngle || !straight && angle > endAngle {
             UIView.animate(withDuration: pow(10, -1000), delay: 0, usingSpringWithDamping: 0.4,
                            initialSpringVelocity: 10,
-                           options: UIViewAnimationOptions.curveEaseIn, animations: { [weak self] in
+                           options: UIView.AnimationOptions.curveEaseIn, animations: { [weak self] in
                             guard let strongSelf = self else {
                                 return
                             }

--- a/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -168,7 +168,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
             }
 
             UIView.animate(withDuration: 0.5, delay: 0,
-                           options: UIViewAnimationOptions(),
+                           options: UIView.AnimationOptions(),
                            animations: { [weak self] in
                             guard let strongSelf = self else {
                                 return
@@ -212,7 +212,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
             }
 
             UIView.animate(withDuration: 0.5, delay: 0,
-                           options: UIViewAnimationOptions(),
+                           options: UIView.AnimationOptions(),
                            animations: { [weak self] in
                 guard let strongSelf = self else {
                     return
@@ -288,7 +288,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
                 calendarView.presentedDate = CVDate(date: date, calendar: calendar)
 
                 UIView.animate(withDuration: toggleDateAnimationDuration, delay: 0,
-                               options: UIViewAnimationOptions(),
+                               options: UIView.AnimationOptions(),
                                animations: {
                     presentedMonth.alpha = 0
                     currentMonthView.alpha = 1

--- a/CVCalendar/CVCalendarMonthView.swift
+++ b/CVCalendar/CVCalendarMonthView.swift
@@ -164,7 +164,7 @@ extension CVCalendarMonthView {
 
     @objc public func didPressInteractiveView(_ recognizer: UILongPressGestureRecognizer) {
         let location = recognizer.location(in: self.interactiveView)
-        let state: UIGestureRecognizerState = recognizer.state
+        let state: UIGestureRecognizer.State = recognizer.state
 
         switch state {
         case .began:

--- a/CVCalendar/CVCalendarView.swift
+++ b/CVCalendar/CVCalendarView.swift
@@ -387,7 +387,7 @@ extension CVCalendarView {
         newController.scrollView.alpha = 0
         addSubview(newController.scrollView)
 
-        UIView.animate(withDuration: 0.5, delay: 0, options: UIViewAnimationOptions(), animations: { [weak self] in
+        UIView.animate(withDuration: 0.5, delay: 0, options: UIView.AnimationOptions(), animations: { [weak self] in
             self?.contentController.scrollView.alpha = 0
             newController.scrollView.alpha = 1
         }) { [weak self] _ in

--- a/CVCalendar/CVCalendarViewAnimator.swift
+++ b/CVCalendar/CVCalendarViewAnimator.swift
@@ -69,7 +69,7 @@ private extension CVCalendarViewAnimator {
 
             UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 0.3,
                                        initialSpringVelocity: 0.1,
-                                       options: UIViewAnimationOptions.beginFromCurrentState,
+                                       options: UIView.AnimationOptions.beginFromCurrentState,
                                        animations: {
                 dayView.selectionView?.transform = CGAffineTransform(scaleX: 1, y: 1)
                 dayView.dayLabel?.transform = CGAffineTransform(scaleX: 1, y: 1)
@@ -82,11 +82,11 @@ private extension CVCalendarViewAnimator {
             dayView, completion in
             UIView.animate(withDuration: 0.15, delay: 0, usingSpringWithDamping: 0.6,
                                        initialSpringVelocity: 0.8,
-                                       options: UIViewAnimationOptions.curveEaseOut, animations: {
+                                       options: UIView.AnimationOptions.curveEaseOut, animations: {
                 dayView.selectionView!.transform = CGAffineTransform(scaleX: 1.3, y: 1.3)
             }) { _ in
                 UIView.animate(withDuration: 0.2, delay: 0,
-                                           options: UIViewAnimationOptions(),
+                                           options: UIView.AnimationOptions(),
                                            animations: {
                     if let selectionView = dayView.selectionView {
                         selectionView.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
@@ -116,7 +116,7 @@ private extension CVCalendarViewAnimator {
         return {
             dayView, completion in
             UIView.animate(withDuration: 0.25, delay: 0,
-                                       options: UIViewAnimationOptions(),
+                                       options: UIView.AnimationOptions(),
                                        animations: { () -> Void in
                 dayView.selectionView?.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
                 dayView.selectionView?.alpha = 0.0

--- a/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -160,7 +160,7 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
             }
 
             UIView.animate(withDuration: toggleDateAnimationDuration, delay: 0,
-                                       options: UIViewAnimationOptions.curveEaseInOut,
+                                       options: UIView.AnimationOptions.curveEaseInOut,
                                        animations: { [weak self] in
                 guard let strongSelf = self else {
                     return
@@ -200,7 +200,7 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
             }
 
             UIView.animate(withDuration: 0.5, delay: 0,
-                                       options: UIViewAnimationOptions(),
+                                       options: UIView.AnimationOptions(),
                                        animations: { [weak self] in
                 guard let strongSelf = self else {
                     return
@@ -278,7 +278,7 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
                 insertWeekView(getFollowingWeek(currentWeekView), withIdentifier: following)
 
                 UIView.animate(withDuration: toggleDateAnimationDuration, delay: 0,
-                                           options: UIViewAnimationOptions(),
+                                           options: UIView.AnimationOptions(),
                                            animations: {
                     presentedWeekView.alpha = 0
                     currentWeekView.alpha = 1

--- a/CVCalendar/CVCalendarWeekView.swift
+++ b/CVCalendar/CVCalendarWeekView.swift
@@ -166,7 +166,7 @@ extension CVCalendarWeekView {
 
     @objc public func didPressInteractiveView(_ recognizer: UILongPressGestureRecognizer) {
         let location = recognizer.location(in: self.interactiveView)
-        let state: UIGestureRecognizerState = recognizer.state
+        let state: UIGestureRecognizer.State = recognizer.state
 
         switch state {
         case .began:

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Version matrix
 
 | CVCalendar | Swift    | Xcode    | Release Notes |
 | ---------- | -------- | -------- | ------------  | 
-|     1.6    | 4.x      | 8.x, 9.x |     HEAD      |
+|     1.6    | 4.x      | 8.x, 9.x, 10.x |     HEAD      |
 |     1.5    | 3.x      | 8.x, 9.x | swift3-branch |
 |     1.4    | 3.x      | 7.x, 8.0 |  Unsupported  |
 |     1.3    | 2.x      | 7.x      |  Unsupported  |

--- a/README.md
+++ b/README.md
@@ -179,13 +179,13 @@ Version matrix
 ==========
 **CVCalendar** adapts the newest swift language syntax but keeps revisions as stated below:
 
-| CVCalendar | Swift    | Xcode    | Release Notes |
-| ---------- | -------- | -------- | ------------  | 
+| CVCalendar | Swift    | Xcode          | Release Notes |
+| ---------- | -------- | -------------- | ------------  | 
 |     1.6    | 4.x      | 8.x, 9.x, 10.x |     HEAD      |
-|     1.5    | 3.x      | 8.x, 9.x | swift3-branch |
-|     1.4    | 3.x      | 7.x, 8.0 |  Unsupported  |
-|     1.3    | 2.x      | 7.x      |  Unsupported  |
-|     1.2    | 1.x      | 7.x      |  Unsupported  |
+|     1.5    | 3.x      | 8.x, 9.x       | swift3-branch |
+|     1.4    | 3.x      | 7.x, 8.0       |  Unsupported  |
+|     1.3    | 2.x      | 7.x            |  Unsupported  |
+|     1.2    | 1.x      | 7.x            |  Unsupported  |
 
 [Advanced API](https://github.com/CVCalendar/CVCalendar/wiki/Advanced-API)
 ==========


### PR DESCRIPTION
Migration from Swift 4.0 to Swift 4.2. 

Basically everything is being migrated with the xcode syntax conversion tool. 

Also updated the example so it runs and the tests are successful. 