### PR TITLE
Pass calendar to convertedDate when receiving a touch in a day view

### DIFF
--- a/CVCalendar.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CVCalendar.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CVCalendar/CVCalendarTouchController.swift
+++ b/CVCalendar/CVCalendarTouchController.swift
@@ -57,15 +57,16 @@ private extension CVCalendarTouchController {
     func receiveTouchOnDayView(_ dayView: CVCalendarDayView,
                                withSelectionType selectionType: CVSelectionType) {
         if let calendarView = dayView.weekView.monthView.calendarView {
+            let calendar = calendarView.delegate?.calendar?() ?? Calendar.current
             switch selectionType {
             case .single:
-                if let convertedDate = dayView.date.convertedDate(),
+                if let convertedDate = dayView.date.convertedDate(calendar: calendar),
                     let earliestDate = calendarView.delegate?.earliestSelectableDate?(),
                     earliestDate.compare(convertedDate) == .orderedDescending {
                     return
                 }
 
-                if let convertedDate = dayView.date.convertedDate(),
+                if let convertedDate = dayView.date.convertedDate(calendar: calendar),
                     let latestDate = calendarView.delegate?.latestSelectableDate?(),
                     latestDate.compare(convertedDate) == .orderedAscending {
                     return


### PR DESCRIPTION
Just to assure that a custom calendar is taking into account when converting dates.