### PR TITLE
Fix toggle day for a week view, in case when any date wasn't selected yet

### DIFF
--- a/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -241,13 +241,22 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
         
         let presentedDate = CVDate(date: date, calendar: calendar)
         guard let _ = monthViews[presented],
-            let presentedWeekView = weekViews[presented],
-            let selectedDate = calendarView.coordinator.selectedDayView?.date else {
-                return
+          let presentedWeekView = weekViews[presented] else {
+            return
         }
-
-        if !matchedDays(selectedDate, CVDate(date: date, calendar: calendar)) && !togglingBlocked {
-            if !matchedWeeks(presentedDate, selectedDate) {
+      
+        var isMatchedDays = false
+        var isMatchedWeeks = false
+      
+        // selectedDayView would be nil if shouldAutoSelectDayOnMonthChange returns false
+        // we want to still allow the user to toggle to a date even if there is nothing selected
+        if let selectedDate = calendarView.coordinator.selectedDayView?.date {
+          isMatchedDays = matchedDays(selectedDate, presentedDate)
+          isMatchedWeeks = matchedWeeks(presentedDate, selectedDate)
+        }
+      
+        if !isMatchedDays && !togglingBlocked {
+          if !isMatchedWeeks {
                 togglingBlocked = true
 
                 weekViews[previous]?.removeFromSuperview()


### PR DESCRIPTION
Applying the same fix https://github.com/CVCalendar/CVCalendar/pull/386 but to CVCalendarWeekContentViewController

### Before Fix
![cvcalendar-before-fix](https://user-images.githubusercontent.com/1839562/49877377-92816a00-fe25-11e8-8ec8-0b43499b0337.gif)

### After Fix
![cvcalendar-after-fix](https://user-images.githubusercontent.com/1839562/49877386-99a87800-fe25-11e8-9a9b-831a62b506c2.gif)
