### PR TITLE
fix: remove setup labels for refresh month

### DIFF
--- a/CVCalendar/CVCalendarContentViewController.swift
+++ b/CVCalendar/CVCalendarContentViewController.swift
@@ -86,7 +86,6 @@ extension CVCalendarContentViewController {
                 dayView.supplementarySetup()
                 dayView.topMarkerSetup()
                 dayView.interactionSetup()
-                dayView.labelSetup()
             }
         }
     }


### PR DESCRIPTION
I found a problem in the latest version `1.6.1`. 
When you refreshed current month it adding duplicates for day view labels, it will add as many labels as you many times you refresh month.

I found that this bug appears after the commit: https://github.com/CVCalendar/CVCalendar/commit/f38f9d461754c9a5a47c76778efb1f5c593a4f39

### Hierarchy view
<img width="765" alt="screen shot 2018-12-13 at 10 55 03 am" src="https://user-images.githubusercontent.com/1839562/49931722-cdd47500-fec7-11e8-962c-f33dc5095ff5.png">
