### PR TITLE
fix: use proper calendar to calculate next month for weekview

### DIFF
--- a/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -381,7 +381,7 @@ extension CVCalendarWeekContentViewController {
 
         components.month! += 1
 
-        let newDate = Calendar.current.date(from: components)!
+        let newDate = calendar.date(from: components)!
         let monthView = MonthView(calendarView: calendarView, date: newDate)
         let frame = CGRect(x: 0, y: 0, width: scrollView.bounds.width,
                            height: scrollView.bounds.height)
@@ -398,7 +398,7 @@ extension CVCalendarWeekContentViewController {
 
         components.month! -= 1
 
-        let newDate = Calendar.current.date(from: components)!
+        let newDate = calendar.date(from: components)!
         let monthView = MonthView(calendarView: calendarView, date: newDate)
         let frame = CGRect(x: 0, y: 0, width: scrollView.bounds.width,
                            height: scrollView.bounds.height)


### PR DESCRIPTION
The problem here that `Calendar.current` was used instead of an instance from the calendarView.

## Before the fix
![cvcalendar-following-date-before](https://user-images.githubusercontent.com/1839562/49940080-e3a16480-fede-11e8-8c5e-5d9918a54523.gif)

## After the fix
![cvcalendar-following-date-after](https://user-images.githubusercontent.com/1839562/49940094-ed2acc80-fede-11e8-89a9-824f1c11e800.gif)
