### PR TITLE
Add delegate method for a week change.

### DIFF
--- a/CVCalendar Demo/CVCalendar Demo/ViewController.swift
+++ b/CVCalendar Demo/CVCalendar Demo/ViewController.swift
@@ -355,5 +355,13 @@ extension ViewController {
         
         print("Showing Month: \(components.month!)")
     }
+  
+    func didShowNextWeekView(from startDayView: DayView, to endDayView: DayView) {
+        print("Showing Week: from \(startDayView.date.day) to \(endDayView.date.day)")
+    }
+  
+    func didShowPreviousWeekView(from startDayView: DayView, to endDayView: DayView) {
+        print("Showing Week: from \(startDayView.date.day) to \(endDayView.date.day)")
+    }
     
 }

--- a/CVCalendar/CVCalendarViewDelegate.swift
+++ b/CVCalendar/CVCalendarViewDelegate.swift
@@ -45,6 +45,9 @@ public protocol CVCalendarViewDelegate {
 
     @objc optional func didShowNextMonthView(_ date: Foundation.Date)
     @objc optional func didShowPreviousMonthView(_ date: Foundation.Date)
+  
+    @objc optional func didShowNextWeekView(from startDayView: DayView, to endDayView: DayView)
+    @objc optional func didShowPreviousWeekView(from startDayView: DayView, to endDayView: DayView)
     
     // Localization
     @objc optional func calendar() -> Calendar?

--- a/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -100,6 +100,11 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
                 replaceWeekView(followingWeek, withIdentifier: self.presented, animatable: true)
 
                 insertWeekView(getFollowingWeek(followingWeek), withIdentifier: following)
+                if let dayViews = followingWeek.dayViews,
+                   let fromDay = dayViews.first,
+                   let toDay = dayViews.last {
+                    self.calendarView.delegate?.didShowNextWeekView?(from: fromDay, to: toDay)
+                }
             }
         }
     }
@@ -114,6 +119,11 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
                 replaceWeekView(previousWeek, withIdentifier: presented, animatable: true)
 
                 insertWeekView(getPreviousWeek(previousWeek), withIdentifier: previous)
+                if let dayViews = previousWeek.dayViews,
+                   let fromDay = dayViews.first,
+                   let toDay = dayViews.last{
+                    self.calendarView.delegate?.didShowPreviousWeekView?(from: fromDay, to: toDay)
+                }
             }
         }
     }
@@ -175,6 +185,11 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
                     strongSelf.prepareTopMarkersOnWeekView(weekView, hidden: false)
                 }
             }
+            if let dayViews = previous.dayViews,
+               let fromDay = dayViews.first,
+               let toDay = dayViews.last {
+                self.calendarView.delegate?.didShowPreviousWeekView?(from: fromDay, to: toDay)
+            }
         }
     }
 
@@ -214,6 +229,11 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
                 for weekView in strongSelf.weekViews.values {
                     strongSelf.prepareTopMarkersOnWeekView(weekView, hidden: false)
                 }
+            }
+            if let dayViews = following.dayViews,
+               let fromDay = dayViews.first,
+               let toDay = dayViews.last {
+                self.calendarView.delegate?.didShowNextWeekView?(from: fromDay, to: toDay)
             }
         }
 


### PR DESCRIPTION
This duplicates logic implemented in a `CVCalendarMonthContentViewController` but for a `CVCalendarWeeksContentViewController`.

Also added usage example  in a demo:
<img width="359" alt="screen shot 2019-01-09 at 9 54 31 am" src="https://user-images.githubusercontent.com/1839562/50887990-dbace580-13f4-11e9-8593-765930056eb0.png">

