### PR TITLE
fix division by zero issue on ios 10

### DIFF
--- a/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -471,7 +471,13 @@ extension CVCalendarMonthContentViewController {
             return
         }
 
-        let page = Int(floor((scrollView.contentOffset.x - scrollView.frame.width / 2) / scrollView.frame.width) + 1)
+        var page = 0
+        if (scrollView.contentOffset.x - scrollView.frame.width) == 0 {
+                page = 1
+        } else {
+            page = Int(floor((scrollView.contentOffset.x - scrollView.frame.width / 2) / scrollView.frame.width) + 1)
+        }
+        
         if currentPage != page {
             currentPage = page
         }


### PR DESCRIPTION
On iOS 10 scrollview.contentOffset.x - scrollView.frame.width returns zero, so at this point CVCalendar is crashing. With this fix it works on iOS 10 and above as well.

#523 