### PR TITLE
Update to allow for Disabled Scrolling in WeekView

### DIFF
--- a/CVCalendar/CVCalendarWeekView.swift
+++ b/CVCalendar/CVCalendarWeekView.swift
@@ -36,6 +36,9 @@ public final class CVCalendarWeekView: UIView {
     fileprivate var touchController: CVCalendarTouchController {
         return calendarView.touchController
     }
+  
+    var allowScrollToPreviousWeek = true
+    var allowScrollToNextWeek = true
 
     // MARK: - Public properties
 


### PR DESCRIPTION
Fixes: #522 and #556 

This PR allows for propagation of the `disableScrollingBeforeDate()` and `disableScrollingBeyondDate()` functions in `.weekView`