### PR TITLE
The earliestSelectableDate is disabled all the time resolved

### DIFF
--- a/CVCalendar Demo/CVCalendar Demo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CVCalendar Demo/CVCalendar Demo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CVCalendar/CVCalendarTouchController.swift
+++ b/CVCalendar/CVCalendarTouchController.swift
@@ -62,7 +62,7 @@ private extension CVCalendarTouchController {
             case .single:
                 if let convertedDate = dayView.date.convertedDate(calendar: calendar),
                     let earliestDate = calendarView.delegate?.earliestSelectableDate?(),
-                    earliestDate.compare(convertedDate) == .orderedDescending {
+                calendar.compare(earliestDate, to: convertedDate, toGranularity: .day) == .orderedDescending  {
                     return
                 }
 


### PR DESCRIPTION
The earliestSelectableDate is disabled all the time when you give earliest and latest date.
It was a critical feature needed for my project so just giving my contributions here.