### PR TITLE
Add shouldSelect option in togglePresentedDate method

### DIFF
--- a/CVCalendar/CVCalendarContentViewController.swift
+++ b/CVCalendar/CVCalendarContentViewController.swift
@@ -129,7 +129,7 @@ extension CVCalendarContentViewController: UIScrollViewDelegate { }
 extension CVCalendarContentViewController {
     @objc public func performedDayViewSelection(_ dayView: DayView) { }
 
-    @objc public func togglePresentedDate(_ date: Foundation.Date) { }
+    @objc public func togglePresentedDate(_ date: Foundation.Date, shouldSelect: Bool = true) { }
 
     @objc public func presentNextView(_ view: UIView?) { }
 

--- a/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -251,7 +251,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
     }
 
     fileprivate var togglingBlocked = false
-    public override func togglePresentedDate(_ date: Foundation.Date) {
+    public override func togglePresentedDate(_ date: Foundation.Date, shouldSelect: Bool = true) {
         let calendar = self.calendarView.delegate?.calendar?() ?? Calendar.current
 
         let presentedDate = CVDate(date: date, calendar: calendar)

--- a/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -294,12 +294,14 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
                     currentMonthView.alpha = 1
                 }) { [weak self] _ in
                     presentedMonth.removeFromSuperview()
-                    self?.selectDayViewWithDay(presentedDate.day, inMonthView: currentMonthView)
+                    if shouldSelect {
+                        self?.selectDayViewWithDay(presentedDate.day, inMonthView: currentMonthView)
+                    }
                     self?.togglingBlocked = false
                     self?.updateLayoutIfNeeded()
                 }
             } else {
-                if let currentMonthView = monthViews[presented] {
+                if let currentMonthView = monthViews[presented], shouldSelect {
                     selectDayViewWithDay(presentedDate.day, inMonthView: currentMonthView)
                 }
             }

--- a/CVCalendar/CVCalendarView.swift
+++ b/CVCalendar/CVCalendarView.swift
@@ -337,14 +337,14 @@ extension CVCalendarView {
         contentController.updateDayViews(shouldShow: shouldShow)
     }
 
-    public func toggleViewWithDate(_ date: Foundation.Date) {
-        contentController.togglePresentedDate(date)
+    public func toggleViewWithDate(_ date: Foundation.Date, shouldSelect: Bool = true) {
+        contentController.togglePresentedDate(date, shouldSelect: shouldSelect)
     }
 
-    public func toggleCurrentDayView() {
-        contentController.togglePresentedDate(Foundation.Date())
+    public func toggleCurrentDayView(shouldSelect: Bool = true) {
+        contentController.togglePresentedDate(Foundation.Date(), shouldSelect: shouldSelect)
     }
-
+    
     public func loadNextView() {
         contentController.presentNextView(nil)
     }

--- a/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -307,11 +307,13 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
                     currentWeekView.alpha = 1
                 }) { [weak self]  _ in
                     presentedWeekView.removeFromSuperview()
-                    self?.selectDayViewWithDay(currentDate.day, inWeekView: currentWeekView)
+                    if shouldSelect {
+                        self?.selectDayViewWithDay(currentDate.day, inWeekView: currentWeekView)
+                    }
                     self?.togglingBlocked = false
                 }
             } else {
-                if let currentWeekView = weekViews[presented] {
+                if let currentWeekView = weekViews[presented], shouldSelect {
                     selectDayViewWithDay(presentedDate.day, inWeekView: currentWeekView)
                 }
             }

--- a/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -250,7 +250,7 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
     }
 
     fileprivate var togglingBlocked = false
-    public override func togglePresentedDate(_ date: Foundation.Date) {
+    public override func togglePresentedDate(_ date: Foundation.Date, shouldSelect: Bool = true) {
         let calendar = self.calendarView.delegate?.calendar?() ?? Calendar.current
         
         let presentedDate = CVDate(date: date, calendar: calendar)


### PR DESCRIPTION
Add `shouldSelect` option parameter in `togglePresentedDate` method.
This determines whether `selectDayViewWithDay` method where is in the end of `togglePresentedDate` method **should be called or not**.

I set `true` as default value for shouldSelect to support legacy codes.

**AS-IS** (CVCalendarContentViewController)
`@objc public func togglePresentedDate(_ date: Foundation.Date) { }`

**TO-BE**
`@objc public func togglePresentedDate(_ date: Foundation.Date, shouldSelect: Bool = true) { }`

This may helps https://github.com/CVCalendar/CVCalendar/issues/251 although it's closed.