### PR TITLE
remove subviews of menu before adding new labels 

### DIFF
--- a/CVCalendar/CVCalendarMenuView.swift
+++ b/CVCalendar/CVCalendarMenuView.swift
@@ -75,6 +75,7 @@ public final class CVCalendarMenuView: UIView {
 
     public func createDaySymbols() {
         // Change symbols with their places if needed.
+        self.removeAllSubviews()
         let dateFormatter = DateFormatter()
         dateFormatter.locale = calendar?.locale ?? Locale.current
         var weekdays: NSArray


### PR DESCRIPTION
This PR has the following changes:
- Removed subviews of calendar menu before adding new labels 

Issue: `createDaySymbols ` function, add new labels to the menu without deleting existing labels. 